### PR TITLE
gcloud ssh needs to be run in the compute context

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The API server will be running an unsecured endpoint on port 8080 on the master 
 You can easily just ssh in to the cluster and run `kubectl` there.  That is probably easiest.
 
 ```
-workstation$ gcloud ssh --zone=us-west1-a kube-master
+workstation$ gcloud compute ssh --zone=us-west1-a kube-master
 kube-master$ kubectl get nodes
 NAME          STATUS    AGE
 kube-master   Ready     1h


### PR DESCRIPTION
Small thing but it bit me, since I am not super familiar with the gcloud utility yet.
